### PR TITLE
READMEにアプリケーションキーを発行するコマンドを追加

### DIFF
--- a/part1/README.md
+++ b/part1/README.md
@@ -2,7 +2,7 @@
 
 ## 実行方法
 
-```
+```sh
 # Dockerの立ち上げ
 docker-compose up
 

--- a/part1/README.md
+++ b/part1/README.md
@@ -1,8 +1,15 @@
 # Part1
+
 ## 実行方法
+
 ```
+# Dockerの立ち上げ
 docker-compose up
+
+# Aprication key の発行
+docker-compose exec phpfpm php artisan key:generate
 ```
 
 ## 確認
+
 http://localhost:8088


### PR DESCRIPTION

```sh
docker-compose up -d
```

だけでは，エラーが出てしまい，動画の最後に登場する Laravel の画面には遷移しませんでした。

エラーを解決するコマンドを README に記述する変更です。